### PR TITLE
Messages

### DIFF
--- a/lib/canable.rb
+++ b/lib/canable.rb
@@ -70,8 +70,8 @@ module Canable
           current_user.can_#{can}?(resource)
         end
 
-        def enforce_#{can}_permission(resource)
-          raise Canable::Transgression unless can_#{can}?(resource)
+        def enforce_#{can}_permission(resource, message="")
+          raise(Canable::Transgression, message) unless can_#{can}?(resource)
         end
         private :enforce_#{can}_permission
       EOM

--- a/test/test_enforcers.rb
+++ b/test/test_enforcers.rb
@@ -20,6 +20,10 @@ class EnforcersTest < Test::Unit::TestCase
         def update
           enforce_update_permission(article)
         end
+
+        def edit
+          enforce_update_permission(article, "You Can't Edit This")
+        end
       end
 
       @article                 = mock('article')
@@ -42,6 +46,15 @@ class EnforcersTest < Test::Unit::TestCase
     should "be able to override can_xx? method" do
       @controller.current_user = nil
       assert_raises(Canable::Transgression) { @controller.update }
+    end
+
+    should "pass message around the stack" do
+      @controller.current_user = nil
+      begin
+        @controller.edit
+      rescue Canable::Transgression => e
+        assert_equal e.message, "You Can't Edit This"
+      end
     end
   end
 end


### PR DESCRIPTION
Add a way to pass a specific message down through the stack.

I have no clue how to test this, but to use it:

```
rescue_from Canable::Transgression, transgression

def transgression(exception)
  flash[:notice] = exception.message
  redirect_to root_url
end
```
