### PR TITLE
Enforcers now raise Transgression when the current_user is nil.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -103,6 +103,28 @@ You can add your own actions like this:
 
 The first parameter is the can method (ie: can_publish?) and the second is the able method (ie: publishable_by?). 
 
+Ables can also be added as class methods. For example, to restrict access to an index action:
+
+    Canable.add(:index, :indexable)
+    
+Then enforce by passing the class instead of the instance:
+
+    class ArticlesController < ApplicationController
+      def index
+        @articles = Article.all
+        enforce_index_permission(Article)
+      end
+    end
+
+Then in the article model, add the able check as a class method:
+
+    class Article
+      ...
+      def self.indexable_by?(user)
+        !user.nil?
+      end
+    end
+
 == Review
 
 So, lets review: cans go on user model, ables go on everything, you override ables in each model where you want to enforce permissions, and enforcers go after each time you find or initialize an object in a controller. Bing, bang, boom.

--- a/lib/canable.rb
+++ b/lib/canable.rb
@@ -67,7 +67,7 @@ module Canable
     def self.add_enforcer_method(can)
       Enforcers.module_eval <<-EOM
         def can_#{can}?(resource)
-          current_user.can_#{can}?(resource)
+          current_user && current_user.can_#{can}?(resource)
         end
 
         def enforce_#{can}_permission(resource, message="")

--- a/test/test_enforcers.rb
+++ b/test/test_enforcers.rb
@@ -9,7 +9,7 @@ class EnforcersTest < Test::Unit::TestCase
 
         # Overriding example
         def can_update?(resource)
-          return false if current_user.nil?
+          return false if current_user && current_user.banned?
           super
         end
 
@@ -42,9 +42,14 @@ class EnforcersTest < Test::Unit::TestCase
       @user.expects(:can_view?).with(@article).returns(false)
       assert_raises(Canable::Transgression) { @controller.show }
     end
-
-    should "be able to override can_xx? method" do
+    
+    should "raise error whenever current_user nil" do
       @controller.current_user = nil
+      assert_raises(Canable::Transgression) { @controller.show }
+    end
+    
+    should "be able to override can_xx? method" do
+      @user.expects(:banned?).returns(true)
       assert_raises(Canable::Transgression) { @controller.update }
     end
 


### PR DESCRIPTION
Hi John,

Thanks for the great gem. Love the simplicity of it, yet does everything you'd need.

The way it expected there to always be a current_user was getting to me though so I've made this change to raise the transgression error (instead of no method on nil error) when the current_user is nil (ie. nobody's logged in).

I've updated the tests accordingly. The old tests btw all passed with the change in place, so the new ones are to prevent regression.

I also added a bit of help on adding checks on class methods as I think it's probably a common thing.

Cheers,
Jo Potts
@jopotts
jopotts@gmail.com
