### PR TITLE
Support for optional handler of successful enforce calls

### DIFF
--- a/lib/canable.rb
+++ b/lib/canable.rb
@@ -70,6 +70,9 @@ module Canable
 
         def enforce_#{can}_permission(resource, message="")
           raise(Canable::Transgression, message) unless can_#{can}?(resource)
+          if respond_to?(:handle_enforce)
+            send(:handle_enforce, :#{can}, resource)
+          end
         end
         private :enforce_#{can}_permission
       EOM


### PR DESCRIPTION
I'm expecting to write one or a few gems that I intend to play nicely with canable.  However, I found myself in the position of needing to monkey patch/alias method chain.  As I basically hate monkey patching, I thought it better to add support for an optional Observer-like behavior.

In this case, when an enforce\* method is called, it will call a "handle_enforce" method on the controller if the controller responds to that message.
