### PR TITLE
Make tests run, and remember which bundle made it possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,3 @@ pkg
 
 ## PROJECT::SPECIFIC
 tmp
-
-Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'http://rubygems.org'
 gemspec
 
-gem 'shoulda', '~> 2.10.2'
-gem 'mocha',   '~> 0.9.8'
+gem 'shoulda'
+gem 'mocha'
 gem 'yard',    '>= 0'
 gem 'rake',    '0.8.7'
 gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,43 @@
+PATH
+  remote: .
+  specs:
+    canable (0.3.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (4.1.0)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    i18n (0.6.9)
+    json (1.8.1)
+    metaclass (0.0.4)
+    minitest (5.3.3)
+    mocha (1.0.0)
+      metaclass (~> 0.0.1)
+    rake (0.8.7)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.1)
+    shoulda-matchers (2.6.1)
+      activesupport (>= 3.0.0)
+    thread_safe (0.3.3)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
+    yard (0.8.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  canable!
+  i18n
+  mocha
+  rake (= 0.8.7)
+  shoulda
+  yard

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
-require 'test/unit'
-require 'mocha'
+require 'minitest/autorun'
+require 'mocha/setup'
 require 'shoulda'
 require 'active_support/all'
 
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'canable'
 
-class Test::Unit::TestCase
+class Minitest::Test
   def Doc(name=nil, &block)
     klass = Struct.new(:name)
     klass.class_eval(&block) if block_given?

--- a/test/test_ables.rb
+++ b/test/test_ables.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class AblesTest < Test::Unit::TestCase
+class AblesTest < Minitest::Test
   context "Class with Canable::Ables included" do
     setup do
       klass = Doc do
@@ -27,22 +27,22 @@ class AblesTest < Test::Unit::TestCase
       assert @resource.destroyable_by?(@user)
     end
   end
-  
+
   context "Class that overrides an able method" do
     setup do
       klass = Doc do
         include Canable::Ables
-        
+
         def viewable_by?(user)
           user.name == 'John'
         end
       end
-      
+
       @resource = klass.new
       @john     = mock('user', :name => 'John')
       @steve    = mock('user', :name => 'Steve')
     end
-    
+
     should "use the overriden method and not default to true" do
       assert @resource.viewable_by?(@john)
       assert ! @resource.viewable_by?(@steve)

--- a/test/test_canable.rb
+++ b/test/test_canable.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestCanable < Test::Unit::TestCase
+class TestCanable < Minitest::Test
   context "Canable" do
     should "have view action by default" do
       assert_equal :viewable, Canable.actions[:view]
@@ -17,14 +17,15 @@ class TestCanable < Test::Unit::TestCase
     should "have destroy action by default" do
       assert_equal :destroyable, Canable.actions[:destroy]
     end
-    
+
     should "be able to add another action" do
       Canable.add(:publish, :publishable)
       assert_equal :publishable, Canable.actions[:publish]
     end
-    
+
     should "know cans" do
-      assert_equal %w(create destroy publish update view), 
+      Canable.add(:publish, :publishable)
+      assert_equal %w(create destroy publish update view),
         Canable.cans.map(&:to_s).sort
     end
   end

--- a/test/test_cans.rb
+++ b/test/test_cans.rb
@@ -1,12 +1,12 @@
 require 'helper'
 
-class CansTest < Test::Unit::TestCase
+class CansTest < Minitest::Test
   context "Class with Canable::Cans included" do
     setup do
       klass = Doc do
         include Canable::Cans
       end
-      
+
       @user = klass.new(:name => 'John')
     end
 

--- a/test/test_enforcers.rb
+++ b/test/test_enforcers.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class EnforcersTest < Test::Unit::TestCase
+class EnforcersTest < Minitest::Test
   context "Including Canable::Enforcers in a class" do
     setup do
       klass = Class.new do
@@ -35,19 +35,20 @@ class EnforcersTest < Test::Unit::TestCase
 
     should "not raise error if can" do
       @user.expects(:can_view?).with(@article).returns(true)
-      assert_nothing_raised { @controller.show }
+      @controller.show
+      # Got this far, so no exception was raised
     end
 
     should "raise error if cannot" do
       @user.expects(:can_view?).with(@article).returns(false)
       assert_raises(Canable::Transgression) { @controller.show }
     end
-    
+
     should "raise error whenever current_user nil" do
       @controller.current_user = nil
       assert_raises(Canable::Transgression) { @controller.show }
     end
-    
+
     should "be able to override can_xx? method" do
       @user.expects(:banned?).returns(true)
       assert_raises(Canable::Transgression) { @controller.update }


### PR DESCRIPTION
Wanted to work on a potential pull request, but tests were not running at all :-( This pull request brings tests back to life.

I can't be 100% sure of what the problem was, but I think it's the following:
1. `Gemfile.lock` was in `.gitignore`
2. As a result, a recently cloned copy of Canable would use a latest ActiveSupport when bundled
3. When last tested, Bundler must have used ActiveSupport version 3.x-ish
4. ActiveSupport started depending on Minitest from version 4.0.0
5. The tests are written using Test::Unit
6. Shoulda and Mocha both were pinned to old versions that did not deal well with both Minitest and Test::Unit being present
7. :zap: :boom: :fire:

So I un-gitignore'd Gemfile.lock, allowed Mocha and Shoulda to upgrade, and converted the tests to Minitest.
